### PR TITLE
provide temp filename 

### DIFF
--- a/django_hashedfilenamestorage/storage.py
+++ b/django_hashedfilenamestorage/storage.py
@@ -5,10 +5,7 @@ import os
 from django.core.files import File
 from django.core.files.storage import FileSystemStorage
 from django.utils.encoding import force_unicode
-
-
-class NoAvailableName(Exception):
-    pass
+import uuid
 
 
 def HashedFilenameMetaStorage(storage_class):
@@ -24,7 +21,10 @@ def HashedFilenameMetaStorage(storage_class):
                 super(HashedFilenameStorage, self).__init__(*args, **kwargs)
 
         def get_available_name(self, name):
-            raise NoAvailableName()
+            dir_name, file_name = os.path.split(name)
+            file_ext = os.path.splitext(file_name)[1]
+
+            return os.path.join(dir_name, '%s.%s' % (uuid.uuid4(), file_ext))
 
         def _get_content_name(self, name, content, chunk_size=None):
             dir_name, file_name = os.path.split(name)


### PR DESCRIPTION
since storage.save will return the final filename anyway, it looks like no hurt to return a temp file name in get_available_name api. 

It will make hashedfilenamestorage compatible to other services. such as `ckeditor_uploadre`.