### PR TITLE
Fix _compute_hash if content received is bytes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Release Notes
 =============
 
+2.1
+-----
+* Fix bug for bytes content
+* Update setup.py and tox to support Django 2.0 for python version >= 3.4
+
 2.0.1
 -----
 * Specify django <2.0 in setup.py

--- a/django_hashedfilenamestorage/storage.py
+++ b/django_hashedfilenamestorage/storage.py
@@ -48,7 +48,9 @@ def HashedFilenameMetaStorage(storage_class):
                     data = content.read(chunk_size)
                     if not data:
                         break
-                    hasher.update(data.encode('utf-8'))
+                    if not isinstance(data, bytes):
+                        data = data.encode('utf-8')
+                    hasher.update(data)
                 return hasher.hexdigest()
             finally:
                 content.seek(cursor)

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,25 @@
 #!/usr/bin/env python
+import sys
+
 from setuptools import setup
+
+
+if sys.version_info < (3, 4):
+    install_requires = ['Django>=1.8,<2.0']
+else:
+    install_requires = ['Django>=1.8,<2.1']
+
 
 setup(
     name='django-hashedfilenamestorage',
-    version='2.0.1',
+    version='2.1',
     description=('A Django storage backend that names files by hash value.'),
     long_description=open('README.rst', 'r').read(),
     author='Ecometrica',
     author_email='info@ecometrica.com',
     url='http://github.com/ecometrica/django-hashedfilenamestorage/',
     packages=['django_hashedfilenamestorage'],
-    install_requires=['Django>=1.8,<2.0'],
+    install_requires=install_requires,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ setenv=
     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
 
 envlist =
-    py36-django{1.11,1.10,1.9,1.8}
-    py35-django{1.11,1.10,1.9,1.8}
+    py36-django{2.0,1.11,1.10,1.9,1.8}
+    py35-django{2.0,1.11,1.10,1.9,1.8}
     py27-django{1.11,1.10,1.9,1.8}
 
 [testenv]
@@ -13,7 +13,8 @@ deps =
     pytest
     pytest-django
     pytest-pythonpath
-    django1.11: Django>1.11,<2.0
+    django2.0: Django>=2.0,<2.1
+    django1.11: Django>=1.11,<2.0
     django1.10: Django>=1.10,<1.11
     django1.9: Django>=1.9,<1.10
     django1.8: Django>=1.8,<1.9


### PR DESCRIPTION
Accommodate `content` being `str` or `bytes` 