### PR TITLE
Allow get_available_filename to return a filename

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Release Notes
 =============
 
+2.2
+-----
+* get_available_filename() now returns the default filename instead of raising
+an exception, for compatibility with other packages (overridden by the hashed
+filename on save)
+
 2.1
 -----
 * Fix bug for bytes content

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ else:
 
 setup(
     name='django-hashedfilenamestorage',
-    version='2.1',
+    version='2.2',
     description=('A Django storage backend that names files by hash value.'),
     long_description=open('README.rst', 'r').read(),
     author='Ecometrica',


### PR DESCRIPTION
Instead of raising a NoAvailableName exception, allow the base class's
get_available_filename to return the default filename.  This will be
overriden on save anyway, but improves compatibility with other packages.
