### PR TITLE
lowercase file extensions

### DIFF
--- a/django_hashedfilenamestorage/storage.py
+++ b/django_hashedfilenamestorage/storage.py
@@ -21,7 +21,7 @@ def HashedFilenameMetaStorage(storage_class):
 
         def _get_content_name(self, name, content, chunk_size=None):
             dir_name, file_name = os.path.split(name)
-            file_ext = os.path.splitext(file_name)[1]
+            file_ext = os.path.splitext(file_name)[1].lower()
             file_root = self._compute_hash(content=content,
                                            chunk_size=chunk_size)
             # file_ext includes the dot.


### PR DESCRIPTION
It does not make any sense to store pnG, pNg, pNG, Png, PnG, PNg, and PNG files alongside with the original png file. The same applies to the other extensions. Moreover, lowercase extensions always looks better than uppercase. So let's make all extensions lowercase.