### PR TITLE
Add support for Django 2.1+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 if sys.version_info < (3, 4):
     install_requires = ['Django>=1.8,<2.0']
 else:
-    install_requires = ['Django>=1.8,<2.1']
+    install_requires = ['Django>=1.8']
 
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ setenv=
     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
 
 envlist =
-    py36-django{2.0,1.11,1.10,1.9,1.8}
-    py35-django{2.0,1.11,1.10,1.9,1.8}
+    py36-django{2.1,2.0,1.11,1.10,1.9,1.8}
+    py35-django{2.1,2.0,1.11,1.10,1.9,1.8}
     py27-django{1.11,1.10,1.9,1.8}
 
 [testenv]
@@ -13,6 +13,7 @@ deps =
     pytest
     pytest-django
     pytest-pythonpath
+    django2.1: Django>=2.1,<2.2
     django2.0: Django>=2.0,<2.1
     django1.11: Django>=1.11,<2.0
     django1.10: Django>=1.10,<1.11


### PR DESCRIPTION
Remove `<2.0` for required Django version. This fixes #13